### PR TITLE
add wrap for long descriptions

### DIFF
--- a/csv2ics.py
+++ b/csv2ics.py
@@ -1,10 +1,11 @@
 import csv
 from datetime import datetime, timedelta
 import os
+import textwrap
 
 print("CSV2ICS")
 print("Licence: GPL-3.0")
-print("17.12.2021 v1.5")
+print("22.02.2024 v1.5.1")
 print("================\n")
 
 c = {}  # Dict containing all calendars
@@ -89,7 +90,7 @@ for key, events in c.items():
         f.write('SUMMARY:' + e[cols["sub"]] + '\n')
         f.write('LOCATION:' + e[cols["loc"]] + '\n')
         f.write('STATUS:CONFIRMED' + '\n')
-        f.write('DESCRIPTION:' + e[cols["dsc"]] + '\n')
+        f.write('DESCRIPTION:' + '\n '.join(textwrap.wrap(e[cols["dsc"]], width=60)) + '\n')
         
         # event footer
         f.write('END:VEVENT\n')


### PR DESCRIPTION
iCalendar Description should not be longer than 75 chars: https://icalendar.org/iCalendar-RFC-5545/3-1-content-lines.html